### PR TITLE
Attempted fix at play command taking too long to start playing.

### DIFF
--- a/src/main/java/dev/westernpine/pulse/manager/Manager.java
+++ b/src/main/java/dev/westernpine/pulse/manager/Manager.java
@@ -53,7 +53,8 @@ public class Manager implements Listener {
         if(this.websocket.isClosed())
             return false;
 
-        Message response = Try.to(() -> this.websocket.getPipeline().send(new Message().withType(MessageType.REQUEST).write("user.premium").write(userId)).get(5, TimeUnit.SECONDS)).orElse(null);
+        //Try to get the premium state in less than 2 seconds, because an interaction on discord times out after 3, and we still need time to process.
+        Message response = Try.to(() -> this.websocket.getPipeline().send(new Message().withType(MessageType.REQUEST).write("user.premium").write(userId)).get(2, TimeUnit.SECONDS)).orElse(null);
         if(response == null)
             return false;
 


### PR DESCRIPTION
This is because in the current production state, there is no premiummaster handler, so getting a response back times out, in which the timeout is 5 seconds. This leaves the interaction as unanswered. This is fixed in 2 ways now:

1. The controller initialization no longer requests premium, but rather a completable future stores this value. And is retrieved upon calling for it.

2. The timeout for a premium request is set to 2 seconds now, instead of 5. This will also help with other interactions when this value is requested.

Up Next:
     - search command, with platform specification, with enqueue target, with selector for witch items to enqueue
     - convert play commands to suboptions
     - filters
     - custom playlists